### PR TITLE
fix: remove check `partial_chain_work` when reorg

### DIFF
--- a/checksums.txt
+++ b/checksums.txt
@@ -1,2 +1,2 @@
 6bbea4820329050e1fc65f9c15cab5948b824c73aa3430d7d92b793c53ca66b6  build/release/can-update-without-ownership-lock
-eaa9e3aeb1205e611078a819e960c33f4934ea49029aab3445a241955e696ee1  build/release/ckb-bitcoin-spv-type-lock
+cfa7d777f246ebd037af156db73c6c7eab3e8e4e1f6e15783a68d2a164875032  build/release/ckb-bitcoin-spv-type-lock

--- a/checksums.txt
+++ b/checksums.txt
@@ -1,2 +1,2 @@
 6bbea4820329050e1fc65f9c15cab5948b824c73aa3430d7d92b793c53ca66b6  build/release/can-update-without-ownership-lock
-cfa7d777f246ebd037af156db73c6c7eab3e8e4e1f6e15783a68d2a164875032  build/release/ckb-bitcoin-spv-type-lock
+cd553a3858df32dbf051957ec97014200e632fed016084b28b25fcbbc49863d1  build/release/ckb-bitcoin-spv-type-lock

--- a/contracts/ckb-bitcoin-spv-type-lock/src/operations/reorg.rs
+++ b/contracts/ckb-bitcoin-spv-type-lock/src/operations/reorg.rs
@@ -26,7 +26,7 @@ pub(crate) fn reorg_clients(inputs: &[usize], outputs: &[usize], script_hash: &[
         expected_info,
         expected_tip_client_id,
         expected_client_ids,
-        previous_chain_work,
+        _previous_chain_work,
         fork_client_id,
         flags,
     ) = {
@@ -53,13 +53,17 @@ pub(crate) fn reorg_clients(inputs: &[usize], outputs: &[usize], script_hash: &[
     let (output_client, output_info_index) =
         load_outputs(outputs, &expected_info, expected_client_ids)?;
     {
-        let new_chain_work: U256 = output_client
-            .headers_mmr_root()
-            .partial_chain_work()
-            .unpack();
-        if previous_chain_work >= new_chain_work {
-            return Err(InternalError::ReorgNotBetterChain.into());
-        }
+        // If there is a limit on the number of headers to update
+        // it may cause the current work to be insufficient, but still on the main chain
+        // so here we no longer check the chain work
+
+        // let new_chain_work: U256 = output_client
+        //     .headers_mmr_root()
+        //     .partial_chain_work()
+        //     .unpack();
+        // if previous_chain_work >= new_chain_work {
+        //     return Err(InternalError::ReorgNotBetterChain.into());
+        // }
     }
     // Finds the only one index of cell deps which use current script.
     // That cell should be the client which at the fork point.

--- a/contracts/ckb-bitcoin-spv-type-lock/src/operations/reorg.rs
+++ b/contracts/ckb-bitcoin-spv-type-lock/src/operations/reorg.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 
 use ckb_bitcoin_spv_verifier::types::{
-    core::{SpvClient, SpvInfo, U256},
+    core::{BitcoinChainType, SpvClient, SpvInfo, U256},
     packed::{self, SpvClientReader, SpvInfoReader, SpvTypeArgsReader, SpvUpdateReader},
     prelude::*,
 };
@@ -26,7 +26,7 @@ pub(crate) fn reorg_clients(inputs: &[usize], outputs: &[usize], script_hash: &[
         expected_info,
         expected_tip_client_id,
         expected_client_ids,
-        _previous_chain_work,
+        previous_chain_work,
         fork_client_id,
         flags,
     ) = {
@@ -53,17 +53,21 @@ pub(crate) fn reorg_clients(inputs: &[usize], outputs: &[usize], script_hash: &[
     let (output_client, output_info_index) =
         load_outputs(outputs, &expected_info, expected_client_ids)?;
     {
-        // If there is a limit on the number of headers to update
-        // it may cause the current work to be insufficient, but still on the main chain
-        // so here we no longer check the chain work
-
-        // let new_chain_work: U256 = output_client
-        //     .headers_mmr_root()
-        //     .partial_chain_work()
-        //     .unpack();
-        // if previous_chain_work >= new_chain_work {
-        //     return Err(InternalError::ReorgNotBetterChain.into());
-        // }
+        // Due to the block storm issue on testnet 3, a large number of blocks may be rolled back
+        // during a reorg, making it necessary to limit the update height.
+        // If there is a limit on the number of headers to update,
+        // the current chain work might not be sufficient but still remain on the main chain.
+        // Therefore, in this case, we no longer check the chain work.
+        // This handling is specific to testnet 3 to address the frequent block storm reorgs.
+        if BitcoinChainType::Testnet != flags.into() {
+            let new_chain_work: U256 = output_client
+                .headers_mmr_root()
+                .partial_chain_work()
+                .unpack();
+            if previous_chain_work >= new_chain_work {
+                return Err(InternalError::ReorgNotBetterChain.into());
+            }
+        }
     }
     // Finds the only one index of cell deps which use current script.
     // That cell should be the client which at the fork point.


### PR DESCRIPTION
Changes to `ckb-bitcoin-spv-type-lock` contract:

* [`contracts/ckb-bitcoin-spv-type-lock/src/operations/reorg.rs`](diffhunk://#diff-05c71783159e4a566e28178dcdd4af65d209ea58ac955c0f76145b6c78f2197aL56-R66): For BTC testnet 3 only, removed the check for chain work in the `reorg_clients` function to avoid issues when the number of headers to update is limited.

Checksum updates:

* [`checksums.txt`](diffhunk://#diff-092ed35ce184329ae3ccf786a43135951d8af11dc3a9bd313435f757626b3527L2-R2): Updated the checksum for the `ckb-bitcoin-spv-type-lock` build.